### PR TITLE
Make sure persist_set_last_error() sets the errno.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <errno.h>
 #include <glib.h>
 #include "linker_set.h"
 #include "internal.h"
@@ -87,6 +88,7 @@ persist_set_last_error(int code, const char *fmt, ...)
 	err = g_malloc0(sizeof(*err));
 	err->code = code;
 	err->message = g_strdup_vprintf(fmt, ap);
+	errno = code;
 	va_end(ap);
 
 	g_private_replace(&persist_last_error, err);


### PR DESCRIPTION
The error code passed to persist_set_last_error() is actually
an errno number, so this function should also update thread-local
errno.